### PR TITLE
イベント作成のデザイン修正（再）

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check": "tsc --noEmit",
     "serve": "(cd functions/ && tsc) && firebase serve",
     "test": "jest",
+    "format": "eslint --fix src/**/*.{ts,js,vue}",
     "deploy": "firebase deploy"
   },
   "dependencies": {

--- a/src/components/EventInputForm.vue
+++ b/src/components/EventInputForm.vue
@@ -1,13 +1,13 @@
 <template>
   <form class="max-w-5xl mx-auto px-2">
-    <div class="md:flex md:items-center mb-0 md:mb-2">
-      <div class="md:w-2/3 p">
+    <div class="md:flex md:items-center pb-0 md:pb-3">
+      <div class="md:w-2/3">
         <div>
           <label for="eventName" class="text-input-label"
             >イベント名<sup class="text-red-500">*</sup></label
           >
         </div>
-        <div class="w-full mb-2 md:mb-0">
+        <div class="w-full pb-3 md:pb-0">
           <input
             id="eventName"
             v-model.trim="eventInput.name"
@@ -19,7 +19,7 @@
           />
         </div>
       </div>
-      <div class="md:w-1/3 md:pl-2 mb-2 md:mb-0">
+      <div class="md:w-1/3 md:pl-2 pb-3 md:pb-0">
         <div>
           <label for="dateOfEvent" class="text-input-label"
             >開催日<sup class="text-red-500">*</sup></label
@@ -58,7 +58,7 @@
     </div>
 
     <div>
-      <div v-for="(talk, index) in eventInput.talks" :key="talk.id" class="transition py-1 md:py-0">
+      <div v-for="(talk, index) in eventInput.talks" :key="talk.id" class="transition pb-3">
         <div class="flex items-center">
           <label for="externalUrl" class="block flex-grow text-input-label"
             >発表枠{{ index + 1 }}</label

--- a/src/components/EventInputForm.vue
+++ b/src/components/EventInputForm.vue
@@ -1,106 +1,104 @@
 <template>
-  <form class="w-full max-w-5xl mx-auto px-2 pt-3">
-    <div class="md:flex md:items-center mb-6">
-      <div class="md:w-1/3">
-        <label
-          for="event_name"
-          class="block text-gray-700 font-bold md:text-right pr-4 mb-1 md:mb-0"
-          >イベント名<sup class="text-red-500">*</sup></label
-        >
+  <form class="max-w-5xl mx-auto px-2">
+    <div class="md:flex md:items-center mb-0 md:mb-2">
+      <div class="md:w-2/3 p">
+        <div>
+          <label for="eventName" class="text-input-label"
+            >イベント名<sup class="text-red-500">*</sup></label
+          >
+        </div>
+        <div class="w-full mb-2 md:mb-0">
+          <input
+            id="eventName"
+            v-model.trim="eventInput.name"
+            type="text"
+            name="eventName"
+            placeholder="Webナイト宮崎 vol.1"
+            class="text-input-form w-full"
+            @input="updateEvent"
+          />
+        </div>
       </div>
-      <div class="md:w-2/3">
-        <input
-          id="event_name"
-          v-model.trim="eventInput.name"
-          type="text"
-          name="event_name"
-          placeholder="Webナイト宮崎 vol.1"
-          class="w-full border-2 border-gray-400 rounded px-2 py-2"
-          @input="updateEvent"
-        />
-      </div>
-    </div>
-    <div class="md:flex md:items-center mb-6">
-      <div class="md:w-1/3">
-        <label
-          for="dateOfEvent"
-          class="block text-gray-700 font-bold md:text-right pr-4 mb-1 md:mb-0"
-          >開催日<sup class="text-red-500">*</sup></label
-        >
-      </div>
-      <div class="md:w-2/3">
-        <input
-          id="dateOfEvent"
-          v-model="eventInput.dateOfEvent"
-          type="date"
-          name="dateOfEvent"
-          placeholder="yyyy-mm-dd"
-          :min="today"
-          class="w-auto border-2 border-gray-400 rounded px-2 py-2"
-          @input="updateEvent"
-        />
+      <div class="md:w-1/3 md:pl-2 mb-2 md:mb-0">
+        <div>
+          <label for="dateOfEvent" class="text-input-label"
+            >開催日<sup class="text-red-500">*</sup></label
+          >
+        </div>
+        <div class="w-full">
+          <input
+            id="dateOfEvent"
+            v-model="eventInput.dateOfEvent"
+            type="date"
+            name="dateOfEvent"
+            placeholder="yyyy-mm-dd"
+            :min="today"
+            class="date-input-form w-full"
+            @input="updateEvent"
+          />
+        </div>
       </div>
     </div>
-    <div class="md:flex md:items-center mb-6">
-      <div class="md:w-1/3">
-        <label
-          for="externalUrl"
-          class="block text-gray-700 font-bold md:text-right pr-4 mb-1 md:mb-0"
-          >イベントページのURL</label
-        >
+
+    <div class="w-full mb-10">
+      <div>
+        <label for="externalUrl" class="text-input-label">イベントページのURL</label>
       </div>
-      <div class="md:w-2/3">
+      <div class="w-full">
         <input
           id="externalUrl"
           v-model.trim="eventInput.externalUrl"
           type="text"
           name="externalUrl"
           placeholder="connpassイベントURLなど (optional)"
-          class="w-full border-2 border-gray-400 rounded px-2 py-2"
+          class="text-input-form w-full"
           @input="updateEvent"
         />
       </div>
     </div>
-    <div
-      v-for="(talk, index) in eventInput.talks"
-      :key="talk.id"
-      class="w-full md:flex md:items-center py-1"
-    >
-      <div class="md:w-1/6 mb-1 md:mb-0">
-        <label for="externalUrl" class="block text-gray-700 font-bold md:text-right pr-4 md:mb-0"
-          >発表枠{{ index + 1 }}</label
-        >
+
+    <div>
+      <div v-for="(talk, index) in eventInput.talks" :key="talk.id" class="transition py-1 md:py-0">
+        <div class="flex items-center">
+          <label for="externalUrl" class="block flex-grow text-input-label"
+            >発表枠{{ index + 1 }}</label
+          >
+          <button
+            type="button"
+            class="border border-green-500 hover:bg-green-500 text-green-500 hover:text-white transition duration-300 rounded px-1 text-xs mr-2"
+            @click="addTalkInput(index)"
+          >
+            ここに発表枠を追加
+          </button>
+          <button type="button" class="text-red-500 text-sm" @click="removeTalk(talk.id)">消</button
+          ><!-- FIXME: FontAwesome -->
+        </div>
+        <div class="md:flex md:items-center md:mb-2">
+          <div class="md:w-1/4 mb-1 md:mb-0">
+            <input
+              v-model.trim="talk.speakerName"
+              type="text"
+              class="text-input-form w-full"
+              placeholder="発表者名"
+              @input="updateEvent"
+            />
+          </div>
+          <div class="md:flex-grow md:pl-2 mb-1 md:mb-0">
+            <input
+              v-model.trim="talk.title"
+              type="text"
+              class="text-input-form w-full"
+              placeholder="発表タイトル"
+              @input="updateEvent"
+            />
+          </div>
+        </div>
       </div>
-      <div class="md:w-1/4 md:px-1 mb-1 md:mb-0">
-        <input
-          v-model.trim="talk.speakerName"
-          type="text"
-          class="w-full border-2 border-gray-400 rounded p-2"
-          placeholder="発表者名"
-          @input="updateEvent"
-        />
-      </div>
-      <div class="md:flex-grow md:px-1 mb-1 md:mb-0">
-        <input
-          v-model.trim="talk.title"
-          type="text"
-          class="w-full border-2 border-gray-400 rounded p-2"
-          placeholder="発表タイトル"
-          @input="updateEvent"
-        />
-      </div>
-      <div class="pl-1">
-        <button type="button" class="text-red-500" @click="removeTalk(talk.id)">消</button
-        ><!-- FIXME: FontAwesome -->
-      </div>
-    </div>
-    <div class="md:flex py-1">
-      <div class="md:w-1/6" />
-      <div class="md:w-5/6 md:px-1">
+      <div class="py-1">
         <button
           type="button"
-          class="w-full border-2 border-green-500 hover:bg-green-500 hover:text-white text-green-500 py-1 rounded transition duration-100"
-          @click="addTalkInput"
+          class="w-full border-2 border-green-500 hover:bg-green-500 hover:text-white text-green-500 py-1 rounded transition duration-300"
+          @click="addTalkInput()"
         >
           発表枠を追加する
         </button>
@@ -111,8 +109,10 @@
 <script lang="ts">
 import dayjs from "dayjs";
 import { defineComponent, onMounted, reactive } from "vue";
+
 import { Event } from "../models/event";
 import { emptyTalk } from "../models/talk";
+
 export default defineComponent({
   name: "EventInput",
   props: {
@@ -132,8 +132,8 @@ export default defineComponent({
       }
     };
 
-    const addTalkInput = () => {
-      eventInput.talks.push(emptyTalk());
+    const addTalkInput = (index?: number) => {
+      eventInput.insertEmptyTalkAt(index);
     };
 
     const removeTalk = (talkId: string) => {

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
     @apply border-2 border-gray-400 rounded px-2 py-2;
   }
   .text-input-label {
-    @apply text-gray-700 font-bold text-sm;
+    @apply text-gray-700 font-bold text-base;
   }
   .date-input-form {
     @apply border-2 border-gray-400 rounded px-2 py-2;

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,16 @@
 @tailwind components;
 
 @tailwind utilities;
+
+@layer components {
+  .text-input-form {
+    @apply border-2 border-gray-400 rounded px-2 py-2;
+  }
+  .text-input-label {
+    @apply text-gray-700 font-bold text-sm;
+  }
+  .date-input-form {
+    @apply border-2 border-gray-400 rounded px-2 py-2;
+    height: 44px;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,18 +2,15 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import "./index.css";
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { faTrashAlt, faThumbsUp } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faTrashAlt, faThumbsUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
-library.add(
-  faTrashAlt,
-  faThumbsUp
-)
+library.add(faTrashAlt, faThumbsUp);
 
 const app = createApp(App);
 
-app.component('FontAwesomeIcon', FontAwesomeIcon)
+app.component("FontAwesomeIcon", FontAwesomeIcon);
 
 app.use(router);
 app.mount("#app");

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,4 +1,4 @@
-import { Talk, TalkResponse } from "./talk";
+import { emptyTalk, Talk, TalkResponse } from "./talk";
 import { v4 as uuidv4 } from "uuid";
 import dayjs from "dayjs";
 
@@ -31,6 +31,14 @@ export class Event {
 
   removeExternalUrl(): void {
     this.externalUrl = undefined;
+  }
+
+  insertEmptyTalkAt(index?: number) {
+    if (index === undefined) {
+      this.talks.push(emptyTalk());
+    } else {
+      this.talks.splice(index, 0, emptyTalk());
+    }
   }
 
   static fromJSON(payload: string): Event {

--- a/src/pages/NewEvent.vue
+++ b/src/pages/NewEvent.vue
@@ -48,8 +48,8 @@
         <button
           type="button"
           :disabled="!formValidated"
-          class="bg-blue-500 opacity-50 cursor-not-allowed text-white px-4 py-2 rounded"
-          :class="{ 'opacity-100 hover:bg-blue-700 cursor-default': formValidated }"
+          class="bg-blue-500 opacity-50 pointer-events-none text-white px-4 py-2 rounded"
+          :class="{ 'opacity-100 hover:bg-blue-700 pointer-events-auto': formValidated }"
           @click="saveCurrentEvent"
         >
           イベントを作成する

--- a/src/pages/NewEvent.vue
+++ b/src/pages/NewEvent.vue
@@ -1,62 +1,58 @@
 <template>
   <div>
-    <h2 class="my-3 text-2xl font-bold">新規イベントを登録する</h2>
+    <h2 class="my-5 text-3xl text-center font-bold">新規イベントを登録する</h2>
 
     <EventInputForm :initial-event="initialEvent" @update-event="updateEvent" />
 
-    <h3 class="w-full mt-3 pt-3 border-t-2 text-xl font-bold">
-      イベントを編集するためのパスワードを設定してください
-    </h3>
-    <div class="md:flex md:items-center mt-6 mb-2">
-      <div class="md:w-1/3">
-        <label for="password" class="block text-gray-700 font-bold md:text-right pr-4 mb-1 md:mb-0"
-          >管理者パスワード</label
+    <h3 class="w-full mt-3 p-5 border-t-2 text-xl text-center font-bold">編集用パスワードの設定</h3>
+    <div class="max-w-4xl mx-auto md:flex md:items-start px-2">
+      <div class="w-full md:w-1/2 md:px-10">
+        <div>
+          <label for="password" class="text-input-label">管理者パスワード</label>
+        </div>
+        <div>
+          <input
+            id="password"
+            v-model="eventPassword"
+            type="password"
+            name="password"
+            placeholder="パスワード"
+            :class="{ 'border-red-500': invalidPassword }"
+            class="text-input-form w-full"
+          />
+        </div>
+      </div>
+      <div class="w-full md:w-1/2 md:px-10">
+        <div>
+          <label for="password_confirm" class="text-input-label">管理者パスワード（確認用）</label>
+        </div>
+        <div>
+          <input
+            id="password_confirm"
+            v-model="eventPasswordConfirm"
+            type="password"
+            name="password_confirm"
+            placeholder="パスワード（確認用）"
+            :class="{ 'border-red-500': invalidPassword }"
+            class="text-input-form w-full"
+          />
+        </div>
+        <span v-show="invalidPassword" class="text-red-500 ml-2 text-sm"
+          >パスワードが一致していません</span
         >
-      </div>
-      <div class="md:w-2/3">
-        <input
-          id="password"
-          v-model="eventPassword"
-          type="password"
-          name="password"
-          placeholder="パスワード"
-          :class="{ 'border-red-500': invalidPassword }"
-          class="border-2 border-gray-400 rounded px-2 py-2"
-        />
-      </div>
-    </div>
-    <div class="md:flex md:items-center mb-6">
-      <div class="md:w-1/3">
-        <label
-          for="password_confirm"
-          class="block text-gray-700 font-bold md:text-right pr-4 mb-1 md:mb-0"
-          >管理者パスワード（確認用）</label
-        >
-      </div>
-      <div class="md:w-2/3">
-        <input
-          id="password_confirm"
-          v-model="eventPasswordConfirm"
-          type="password"
-          name="password_confirm"
-          placeholder="パスワード（確認用）"
-          :class="{ 'border-red-500': invalidPassword }"
-          class="border-2 border-gray-400 rounded px-2 py-2"
-        />
-        <span v-show="invalidPassword" class="text-red-500 ml-2">パスワードが一致していません</span>
       </div>
     </div>
 
-    <div class="text-center py-5">
+    <div class="text-center py-8">
       <div class="">
         <button
           type="button"
           :disabled="!formValidated"
-          class="bg-blue-500 opacity-50 text-white px-4 py-2 rounded"
-          :class="{ 'opacity-100 hover:bg-blue-700': formValidated }"
+          class="bg-blue-500 opacity-50 cursor-not-allowed text-white px-4 py-2 rounded"
+          :class="{ 'opacity-100 hover:bg-blue-700 cursor-default': formValidated }"
           @click="saveCurrentEvent"
         >
-          イベント情報を保存する
+          イベントを作成する
         </button>
       </div>
     </div>

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -2,19 +2,19 @@ import { FirebaseCommentRepository, FirebaseEventRepository } from "./firebase";
 import { CommentRepository, EventRepository } from "./interface";
 import { LocalStorageCommentRepository, LocalStorageEventRepository } from "./local_storage";
 
-const event_repository: EventRepository =
+const eventRepository: EventRepository =
   process.env.NODE_ENV == "production"
     ? new FirebaseEventRepository()
     : new LocalStorageEventRepository();
 
-const comment_repository: CommentRepository =
+const commentRepository: CommentRepository =
   process.env.NODE_ENV == "production"
     ? new FirebaseCommentRepository()
     : new LocalStorageCommentRepository();
 
-export const saveEvent = event_repository.save;
-export const findEventById = event_repository.findById;
-export const verifyEventPassword = event_repository.verifyPassword;
-export const saveComment = comment_repository.save;
-export const findAllCommentByEventId = comment_repository.findAllByEventId;
-export const saveCommentLike = comment_repository.saveLike;
+export const saveEvent = eventRepository.save;
+export const findEventById = eventRepository.findById;
+export const verifyEventPassword = eventRepository.verifyPassword;
+export const saveComment = commentRepository.save;
+export const findAllCommentByEventId = commentRepository.findAllByEventId;
+export const saveCommentLike = commentRepository.saveLike;

--- a/src/repository/local_storage.ts
+++ b/src/repository/local_storage.ts
@@ -9,8 +9,8 @@ export class LocalStorageEventRepository implements EventRepository {
   save(event: Event, password: string): Promise<Event> {
     const payload = storage.getItem(`event-${event.id}`);
     if (payload) {
-      const password_hashed = storage.getItem(`event-${event.id}-password`);
-      if (jssha256.sha256(password) == password_hashed) {
+      const passwordHashed = storage.getItem(`event-${event.id}-password`);
+      if (jssha256.sha256(password) == passwordHashed) {
         storage.setItem(`event-${event.id}`, JSON.stringify(event));
         return Promise.resolve(event);
       } else {
@@ -33,19 +33,19 @@ export class LocalStorageEventRepository implements EventRepository {
   }
 
   verifyPassword(eventId: string, password: string): Promise<boolean> {
-    const password_hashed = storage.getItem(`event-${eventId}-password`);
-    return Promise.resolve(jssha256.sha256(password) == password_hashed);
+    const passwordHashed = storage.getItem(`event-${eventId}-password`);
+    return Promise.resolve(jssha256.sha256(password) == passwordHashed);
   }
 }
 
 export class LocalStorageCommentRepository implements CommentRepository {
   save(comment: Comment): Promise<Comment> {
     const comments = Comment.fromJSONArray(storage.getItem("comments") || "[]");
-    const replace_index = comments.findIndex((c) => c.id == comment.id);
-    if (replace_index < 0) {
+    const replaceIndex = comments.findIndex((c) => c.id == comment.id);
+    if (replaceIndex < 0) {
       comments.push(comment);
     } else {
-      comments[replace_index] = comment;
+      comments[replaceIndex] = comment;
     }
     storage.setItem(`comments`, JSON.stringify(comments));
     return Promise.resolve(comment);
@@ -53,8 +53,8 @@ export class LocalStorageCommentRepository implements CommentRepository {
 
   findAllByEventId(eventId: EventId): Promise<Comment[]> {
     const comments = Comment.fromJSONArray(storage.getItem("comments") || "[]");
-    const target_comments = comments.filter((c) => c.eventId == eventId);
-    return Promise.resolve(target_comments);
+    const targetComments = comments.filter((c) => c.eventId == eventId);
+    return Promise.resolve(targetComments);
   }
 
   saveLike(
@@ -64,11 +64,11 @@ export class LocalStorageCommentRepository implements CommentRepository {
     remove: boolean
   ): Promise<boolean> {
     const comments = Comment.fromJSONArray(storage.getItem("comments") || "[]");
-    const target_comment = comments.find((c) => c.id == commentId);
-    if (!target_comment) {
+    const targetComment = comments.find((c) => c.id == commentId);
+    if (!targetComment) {
       return Promise.reject();
     }
-    target_comment.setLike(userIdHashed, remove);
+    targetComment.setLike(userIdHashed, remove);
     storage.setItem(`comments`, JSON.stringify(comments));
     return Promise.resolve(true);
   }


### PR DESCRIPTION
## issue

issueの粒度が大きいためクローズできるとは言えないが、関連としておく。

#3 

## やったこと

- イベント情報と登壇者枠のレイアウトがガタガタだったので、項目名を左上に統一して入力枠の左右幅をいっぱいにしてみた
- パスワード入力欄を左右の配置にした
- 登壇枠の途中挿入をできるようにした（このUIがわかりやすいかはさておき）

## 注意

#20 を先にマージすること