### PR TITLE
UUIDv4 の代わりに Nano ID を使う

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,13 @@
     "axios": "^0.20.0",
     "dayjs": "^1.9.1",
     "js-sha256": "^0.9.0",
+    "nanoid": "^3.1.16",
     "tailwindcss": "^1.8.10",
-    "uuid": "^8.3.0",
     "vue": "^3.0.0",
     "vue-router": "^4.0.0-beta.13"
   },
   "devDependencies": {
     "@types/jest": "^26.0.14",
-    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
     "@vue/compiler-sfc": "^3.0.0",

--- a/src/models/comment.spec.ts
+++ b/src/models/comment.spec.ts
@@ -1,8 +1,8 @@
 import { Comment } from "./comment";
-import { v4 as uuidv4 } from "uuid";
+import { nanoid } from "nanoid";
 
 test("Successful JSON conversion", () => {
-  const comment = new Comment("新しいコメント", uuidv4(), uuidv4(), uuidv4());
+  const comment = new Comment("新しいコメント", nanoid(), nanoid(8), nanoid());
 
   const commentString = JSON.stringify(comment);
   const result = Comment.fromJSON(commentString);
@@ -12,9 +12,9 @@ test("Successful JSON conversion", () => {
 });
 
 test("Successful JSONArray conversion", () => {
-  const userId = uuidv4();
-  const eventId = uuidv4();
-  const talkId = uuidv4();
+  const userId = nanoid();
+  const eventId = nanoid(8);
+  const talkId = nanoid();
   const comments = [
     new Comment("新しいコメント", userId, eventId, talkId),
     new Comment("別の新しいコメント", userId, eventId, talkId),

--- a/src/models/comment.ts
+++ b/src/models/comment.ts
@@ -1,14 +1,14 @@
 import dayjs, { Dayjs } from "dayjs";
-import { v4 as uuidv4 } from "uuid";
+import { nanoid } from "nanoid";
 
 export type CommentId = string;
 export class Comment {
-  id: CommentId; // UUID
+  id: CommentId;
   text: string;
-  userIdHashed: string; // FIXME: userId のハッシュ値を入れる(なりすまし防止)
+  userIdHashed: string; // userId のハッシュ値を入れる(なりすまし防止)
   postedAt: Dayjs; // datetime
-  eventId: string; // UUID
-  talkId: string; // UUID
+  eventId: string;
+  talkId: string;
   likes: string[];
 
   constructor(
@@ -20,7 +20,7 @@ export class Comment {
     postedAt?: Dayjs,
     likes?: string[]
   ) {
-    this.id = id || uuidv4();
+    this.id = id || nanoid();
     this.text = text;
     this.userIdHashed = userIdHashed;
     this.postedAt = postedAt || dayjs();
@@ -84,11 +84,11 @@ export class Comment {
 }
 
 export type CommentResponse = {
-  id: string; // UUID
+  id: string;
   text: string;
-  userIdHashed: string; // UUID
+  userIdHashed: string;
   postedAt: string; // datetime
-  eventId: string; // UUID
-  talkId: string; // UUID
+  eventId: string;
+  talkId: string;
   likes: string[];
 };

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,11 +1,11 @@
 import { emptyTalk, Talk, TalkResponse } from "./talk";
-import { v4 as uuidv4 } from "uuid";
+import { nanoid } from "nanoid";
 import dayjs from "dayjs";
 
 export type EventId = string;
 
 export class Event {
-  id: EventId; // UUID
+  id: EventId;
   name: string;
   dateOfEvent: string; // date
   talks: Talk[];
@@ -18,7 +18,7 @@ export class Event {
     talks?: Talk[],
     externalUrl?: string
   ) {
-    this.id = id || uuidv4();
+    this.id = id || nanoid(8);
     this.name = name;
     this.dateOfEvent = dateOfEvent;
     this.talks = talks || [];
@@ -66,7 +66,7 @@ export class Event {
 }
 
 type EventResponse = {
-  id: string; // UUID
+  id: string;
   name: string;
   dateOfEvent: string; // date
   talks: TalkResponse[];

--- a/src/models/talk.ts
+++ b/src/models/talk.ts
@@ -1,13 +1,14 @@
+import { nanoid } from "nanoid";
+
 export type TalkId = string;
-import { v4 as uuidv4 } from "uuid";
 
 export class Talk {
-  id: TalkId; // UUID
+  id: TalkId;
   title: string;
   speakerName: string;
 
   constructor(title: string, speakerName: string, id?: string) {
-    this.id = id || uuidv4();
+    this.id = id || nanoid();
     this.title = title;
     this.speakerName = speakerName;
   }

--- a/src/models/user_context.ts
+++ b/src/models/user_context.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { nanoid } from "nanoid";
 import jssha256 from "js-sha256";
 
 type UserId = string;
@@ -9,7 +9,7 @@ export class UserContext {
   commentOrder: CommentOrder;
 
   constructor(userId?: UserId, commentOrder?: CommentOrder) {
-    this.userId = userId || uuidv4();
+    this.userId = userId || nanoid();
     this.userIdHashed = jssha256.sha256(this.userId);
     this.commentOrder = commentOrder || CommentOrder.DescendingTimeOrder;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,11 +1013,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -5930,6 +5925,11 @@ nan@^2.14.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoid@^3.1.16:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
 nanomatch@^1.2.9:
   version "1.2.13"


### PR DESCRIPTION
イベントなどのIDにUUIDを使っているが、URLが長すぎるので [Nano ID](https://github.com/ai/nanoid) を使ってみてはどうだろうか、という提案。

- 生成されるIDの長さを短くすれば衝突可能性が上がるが、 Event ID のように生成される頻度がそもそも低いものに関しては短くしても十分に衝突しないことが担保できる。シミュレーターで試せる。
- UUIDv4より生成速度が速いらしい。

