### PR TITLE
[update] イベント編集時のパスワード入力モーダルからイベントページに戻るリンクを追加

### DIFF
--- a/src/pages/EventEdit.vue
+++ b/src/pages/EventEdit.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <div v-show="!passwordVerified" class="fixed z-10 inset-0 overflow-y-auto">
-      <div
-        class="flex item-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
-      >
+      <div class="min-h-screen pt-4 px-4 pb-20 text-center sm:p-0">
         <div class="fixed inset-0 transition-opacity">
           <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
         </div>
@@ -12,6 +10,11 @@
           class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle max-w-lg sm:w-full"
         >
           <div class="bg-white p-4">
+            <div class="mb-2">
+              <router-link :to="`/event/${eventId}`">
+                <span class="text-gray-500 underline">&lt;&nbsp;イベントページに戻る</span>
+              </router-link>
+            </div>
             <div class="text-lg pb-2">パスワードの確認</div>
             <div class="flex items-center">
               <div class="flex-grow pr-3">


### PR DESCRIPTION
## チケット
https://github.com/tegehoge/LeacTion/issues/42

## やったこと
- イベントページのパスワードモーダルに、「イベントページへ戻る」リンクを追加した
- ついでに、スマホで開いた時にパスワードモーダルが縦に伸びてしまっていたので、親 div の class を修正
![image](https://user-images.githubusercontent.com/31984716/99891371-ae961300-2cac-11eb-9372-5ef11ce3d7a4.png)

## 見て欲しいこと
スマホでパスワードのモーダルが縦に伸びてしまうので親 div の flex を外したんですが、他に影響ないか見て欲しいです！（パッと見では大丈夫そうな気がしているけど、、）