### PR TITLE
イベントページのリデザイン

### DIFF
--- a/src/components/CommentBlock.vue
+++ b/src/components/CommentBlock.vue
@@ -20,14 +20,18 @@
         </div>
         <div>
           <button
-            class="bg-green-500 text-white px-2 rounded-full"
+            class="text-white px-2 rounded-full"
             title="いいね！"
             type="button"
-            :class="{ 'bg-pink-500': isLiked, 'opacity-50': isMine }"
+            :class="{
+              'bg-green-500': !isMine,
+              'bg-gray-500 opacity-50 cursor-not-allowed': isMine,
+            }"
             :disabled="isMine"
             @click="toggleLike"
           >
-            <font-awesome-icon :icon="['fas', 'thumbs-up']" />
+            <font-awesome-icon v-if="!isLiked" :icon="['fas', 'thumbs-up']" />
+            <font-awesome-icon v-if="isLiked" :icon="['fas', 'check']" />
             <span class="font-mono pl-1">{{ likeCount }}</span>
           </button>
         </div>
@@ -97,4 +101,17 @@ export default defineComponent({
 });
 </script>
 
-<style></style>
+<style scoped>
+.like-button-enter-active,
+.like-button-leave-active {
+  transition: opacity 0.5s;
+}
+.like-button-enter-to,
+.like-button-leave-from {
+  opacity: 1;
+}
+.like-button-enter-from,
+.like-button-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/CommentBlock.vue
+++ b/src/components/CommentBlock.vue
@@ -72,12 +72,10 @@ export default defineComponent({
       let cursor = 0;
       let result = "";
       for (const match of matches) {
+        const urlForAttr = xssFilters.uriInDoubleQuotedAttr(match[0]);
+        const urlForHtml = xssFilters.uriInHTMLData(match[0]);
         result += props.comment.text.slice(cursor, match.index || cursor);
-        result += `<a href="${xssFilters.uriInDoubleQuotedAttr(
-          match[0]
-        )}" class="underline text-blue-700" target="_blank" rel="noopener noreferrer">${xssFilters.uriInHTMLData(
-          match[0]
-        )}</a>`;
+        result += `<a href="${urlForAttr}" class="underline text-blue-700" target="_blank" rel="noopener noreferrer">${urlForHtml}</a>`;
         cursor = (match.index || cursor) + match[0].length;
       }
       result += props.comment.text.slice(cursor);

--- a/src/components/CommentBlock.vue
+++ b/src/components/CommentBlock.vue
@@ -1,39 +1,39 @@
 <template>
-  <div class="w-full sm:w-1/2 md:w-1/3 my-2">
-    <div class="rounded shadow-md mx-2 overflow-hidden h-full">
-      <div class="flex flex-col px-4 py-3 bg-yellow-200 h-full">
-        <div class="flex-grow text-lg text-left">
-          <span v-html="message"></span>
+  <div class="w-full my-1">
+    <div
+      class="rounded-lg shadow-md mx-2 px-2 py-2 bg-yellow-200 h-full"
+      :title="comment.postedAt.format('YYYY-MM-DD HH:mm:ss')"
+    >
+      <div class="float-right flex">
+        <div>
+          <button
+            v-if="isMine"
+            class="text-red-500 px-2 mr-1"
+            type="button"
+            title="コメントを削除する"
+            @click="deleteMyComment"
+          >
+            <span>
+              <font-awesome-icon :icon="['fas', 'trash-alt']" />
+            </span>
+          </button>
         </div>
-        <div class="flex items-end text-sm">
-          <div class="flex-grow text-black opacity-25">
-            {{ comment.postedAt.format("YYYY-MM-DD HH:mm:ss") }}
-          </div>
-          <div>
-            <button
-              v-if="isMine"
-              class="bg-red-500 text-white px-3 py-1 mr-1 rounded-full"
-              type="button"
-              @click="deleteMyComment"
-            >
-              <span>
-                <font-awesome-icon :icon="['fas', 'trash-alt']" />
-              </span>
-            </button>
-            <button
-              class="bg-green-500 text-white px-3 py-1 rounded-full"
-              type="button"
-              :class="{ 'bg-pink-500': isLiked, 'opacity-50': isMine }"
-              :disabled="isMine"
-              @click="toggleLike"
-            >
-              <span class="mr-1">
-                <font-awesome-icon :icon="['fas', 'thumbs-up']" />
-              </span>
-              <span>{{ likeCount }}</span>
-            </button>
-          </div>
+        <div>
+          <button
+            class="bg-green-500 text-white px-2 rounded-full"
+            title="いいね！"
+            type="button"
+            :class="{ 'bg-pink-500': isLiked, 'opacity-50': isMine }"
+            :disabled="isMine"
+            @click="toggleLike"
+          >
+            <font-awesome-icon :icon="['fas', 'thumbs-up']" />
+            <span class="font-mono pl-1">{{ likeCount }}</span>
+          </button>
         </div>
+      </div>
+      <div class="flex-grow text-lg text-left">
+        <span class="break-all" v-html="message"></span>
       </div>
     </div>
   </div>

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faTrashAlt,
   faThumbsUp,
+  faCheck,
   faSpinner,
   faBars,
   faShareAlt,
@@ -22,6 +23,7 @@ import AppHeader from "./components/AppHeader.vue";
 library.add(
   faTrashAlt,
   faThumbsUp,
+  faCheck,
   faSpinner,
   faBars,
   faShareAlt,

--- a/src/pages/Event.vue
+++ b/src/pages/Event.vue
@@ -124,6 +124,7 @@ export default defineComponent({
         fetchComments();
         haveReadAll.value = false;
       }
+      checkRead();
       setTimeout(scrollToBottom, 0);
     };
 


### PR DESCRIPTION
## issue

#3 
#50 
#53 

## ScreenShot

<img width="918" alt="スクリーンショット 2021-04-06 15 29 08" src="https://user-images.githubusercontent.com/611276/113668251-eac29100-96ec-11eb-852d-facf6f66e2c6.png">

<img width="326" alt="スクリーンショット 2021-04-06 15 30 11" src="https://user-images.githubusercontent.com/611276/113668310-029a1500-96ed-11eb-85af-b934e152cd6a.png">

## 変更点

- 時刻表示を消した（マウスオーバーで表示）
- 「いいね！」したらチェックマークになる
- いいね数の文字の幅でボタンがガタガタ動くのが好みでなかったのでとりあえず monospace にしてみた
- 全体的に省スペース化
- ボタン下に文字が回り込めるように `float-right` を適用
- 色の調整