### PR TITLE
改行を入力可能にする

### DIFF
--- a/src/components/CommentBlock.vue
+++ b/src/components/CommentBlock.vue
@@ -66,13 +66,12 @@ export default defineComponent({
     const isLiked = computed(() => props.comment.isLikedBy(props.userIdHashed) || false);
     const isMine = computed(() => props.comment.userIdHashed == props.userIdHashed);
     const message = computed(() => {
-      const matches = props.comment.text.matchAll(
-        /https?:\/\/([\w-]+\.)+[\w:-]+(\/[\w ./?%&=~-]*)?/g
-      );
+      const target = props.comment.text.replace(/ /g, "&nbsp;");
+      const matches = target.matchAll(/https?:\/\/([\w-]+\.)+[\w:-]+(\/[\w ./?%&=~-]*)?/g);
       let cursor = 0;
       let result = "";
       for (const match of matches) {
-        result += props.comment.text.slice(cursor, match.index || cursor);
+        result += target.slice(cursor, match.index || cursor);
         result += `<a href="${xssFilters.uriInDoubleQuotedAttr(
           match[0]
         )}" class="underline text-blue-700" target="_blank" rel="noopener noreferrer">${xssFilters.uriInHTMLData(
@@ -80,8 +79,8 @@ export default defineComponent({
         )}</a>`;
         cursor = (match.index || cursor) + match[0].length;
       }
-      result += props.comment.text.slice(cursor);
-      return result;
+      result += target.slice(cursor);
+      return result.replace(/\r\n|\r|\n/g, "<br />");
     });
     const deleteMyComment = () => {
       if (confirm("削除してよろしいですか？")) {

--- a/src/components/CommentInput.vue
+++ b/src/components/CommentInput.vue
@@ -1,13 +1,16 @@
 <template>
-  <div class="flex px-3 py-2 w-full text-center items-center mx-auto">
+  <div class="flex px-3 py-2 w-full text-center items-start mx-auto">
     <div class="flex-grow pr-2">
-      <input
+      <textarea
         id="commentInput"
         ref="inputForm"
-        v-model="commentInput"
-        type="text"
+        v-model.trim="commentInput"
         class="w-full border-2 rounded p-2"
         placeholder="質問・コメント"
+        :rows="lineCount"
+        @keydown.enter.prevent
+        @keydown.enter.exact="addNewline()"
+        @keydown.shift.enter.exact="sendComment()"
       />
     </div>
     <div>
@@ -18,7 +21,7 @@
         :disabled="!canSend"
         @click="sendComment()"
       >
-        投稿する(Enter)
+        投稿する<span class="hidden md:inline">(Shift+Enter)</span>
       </button>
     </div>
   </div>
@@ -47,33 +50,34 @@ export default defineComponent({
   emits: ["add-comment"],
   setup(props, { emit }) {
     const commentInput = ref("");
-    const inputForm = ref<HTMLInputElement>();
-    const canSend = computed(() => commentInput.value != "");
+    const inputForm = ref<HTMLTextAreaElement>();
+    const canSend = computed(() => commentInput.value.replace(/\s*/m, "") !== "");
+    const lineCount = computed(() => commentInput.value.split(/\r\n|\r|\n/).length);
 
     const sanitizeText = (text: string) => text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
     const sendComment = () => {
-      const comment = new Comment(
-        sanitizeText(commentInput.value),
-        props.userIdHashed,
-        props.eventId,
-        props.talkId
-      );
-      emit("add-comment", comment);
-      commentInput.value = "";
-      inputForm.value?.focus();
+      if (canSend.value) {
+        const comment = new Comment(
+          sanitizeText(commentInput.value),
+          props.userIdHashed,
+          props.eventId,
+          props.talkId
+        );
+        emit("add-comment", comment);
+        commentInput.value = "";
+        inputForm.value?.focus();
+      }
+    };
+
+    const addNewline = () => {
+      commentInput.value = `${commentInput.value}\n`;
     };
 
     onMounted(() => {
-      // Enterでコメント送信を可能にする
-      inputForm.value?.addEventListener("keydown", (e) => {
-        if (e.keyCode == 13 && commentInput.value) {
-          sendComment();
-        }
-      });
       inputForm.value?.focus();
     });
-    return { commentInput, sendComment, inputForm, canSend };
+    return { commentInput, lineCount, sendComment, addNewline, inputForm, canSend };
   },
 });
 </script>


### PR DESCRIPTION
## issue

#40 

## 空白の扱い

- `v-model.trim` を使うことで先頭・末尾の余分な空白を削除している
- 連続した半角スペースをそれっぽく表示するために `&nbsp;` への変換を行っている（不要？）