### PR TITLE
イベントハッシュタグを登録可能にする

### DIFF
--- a/src/components/EventHeader.vue
+++ b/src/components/EventHeader.vue
@@ -9,6 +9,16 @@
           <div class="flex-grow text-center">
             <h2 class="text-2xl">{{ eventTitle }}</h2>
           </div>
+          <div v-if="eventHashtag.length > 0" class="hidden md:block">
+            <a
+              :href="`https://twitter.com/intent/tweet/?hashtags=${eventHashtag}`"
+              target="_blank"
+              rel="noopener noreferrer"
+              ><button class="twitter-share-button">
+                <font-awesome-icon :icon="['fab', 'twitter']" /> tweet #{{ eventHashtag }}
+              </button></a
+            >
+          </div>
           <div>
             <button
               type="button"
@@ -25,6 +35,16 @@
         v-if="showMenu"
         class="md:flex md:items-center md:justify-between container mx-auto px-2 md:px-0 md:py-2"
       >
+        <li v-if="eventHashtag.length > 0" class="w-full md:hidden border-t py-2 pl-6">
+          <a
+            :href="`https://twitter.com/intent/tweet/?hashtags=${eventHashtag}`"
+            target="_blank"
+            rel="noopener noreferrer"
+            ><button class="twitter-share-button">
+              <font-awesome-icon :icon="['fab', 'twitter']" /> tweet #{{ eventHashtag }}
+            </button></a
+          >
+        </li>
         <li class="w-full md:w-1/3 md:text-center border-t md:border-t-0 md:border-r">
           <a class="block w-full my-2 md:my-0 py-2 px-6 cursor-pointer" @click="openShareModal">
             <font-awesome-icon :icon="['fas', 'share-alt']" class="mr-2" />イベントをシェアする</a
@@ -107,6 +127,10 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    eventHashtag: {
+      type: String,
+      required: true,
+    },
   },
   components: { Modal },
   setup(props, context) {
@@ -133,6 +157,10 @@ export default defineComponent({
       const url = new URL("https://twitter.com/intent/tweet");
       url.searchParams.append("text", `LeacTion で「${props.eventTitle}」にリアクションしよう！`);
       url.searchParams.append("url", currentUrl);
+      url.searchParams.append(
+        "hashtags",
+        props.eventHashtag.length > 0 ? `${props.eventHashtag},LeacTion` : "LeacTion"
+      );
       return url;
     });
 
@@ -140,3 +168,15 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="postcss" scoped>
+.twitter-share-button {
+  color: white;
+  background-color: #1b95e0;
+  border-radius: 3px;
+  padding: 0.25em 0.5em;
+}
+.twitter-share-button:hover {
+  background-color: #0c7abf;
+}
+</style>

--- a/src/components/EventInputForm.vue
+++ b/src/components/EventInputForm.vue
@@ -69,6 +69,7 @@
             type="text"
             name="hashtag"
             placeholder="Webナイト宮崎"
+            pattern="([^\s!$%^&*+.]*[^0-9\s!$%^&*+.][^\s!$%^&*+.]*)?"
             class="w-full pl-6 text-input-form"
             @input="updateEvent"
           />
@@ -227,5 +228,8 @@ export default defineComponent({
 <style scoped>
 .ghost {
   opacity: 0.5;
+}
+#hashtag:invalid {
+  border-color: red;
 }
 </style>

--- a/src/components/EventInputForm.vue
+++ b/src/components/EventInputForm.vue
@@ -40,20 +40,39 @@
       </div>
     </div>
 
-    <div class="w-full mb-10">
-      <div>
-        <label for="externalUrl" class="text-input-label">イベントページのURL</label>
+    <div class="md:flex mb-10">
+      <div class="w-full md:w-2/3 pb-3 md:pb-0">
+        <div>
+          <label for="externalUrl" class="text-input-label">イベントページのURL</label>
+        </div>
+        <div class="w-full">
+          <input
+            id="externalUrl"
+            v-model.trim="eventInput.externalUrl"
+            type="text"
+            name="externalUrl"
+            placeholder="connpassイベントURLなど (optional)"
+            class="text-input-form w-full"
+            @input="updateEvent"
+          />
+        </div>
       </div>
-      <div class="w-full">
-        <input
-          id="externalUrl"
-          v-model.trim="eventInput.externalUrl"
-          type="text"
-          name="externalUrl"
-          placeholder="connpassイベントURLなど (optional)"
-          class="text-input-form w-full"
-          @input="updateEvent"
-        />
+      <div class="w-full md:w-1/3 md:pl-2 pb-3 md:pb-0">
+        <div>
+          <label for="hashtag" class="text-input-label">Twitterハッシュタグ</label>
+        </div>
+        <div class="relative w-full">
+          <div class="absolute inset-y-0 pl-3 flex items-center"><span>#</span></div>
+          <input
+            id="hashtag"
+            v-model.trim="eventInput.hashtag"
+            type="text"
+            name="hashtag"
+            placeholder="Webナイト宮崎"
+            class="w-full pl-6 text-input-form"
+            @input="updateEvent"
+          />
+        </div>
       </div>
     </div>
 

--- a/src/models/event.spec.ts
+++ b/src/models/event.spec.ts
@@ -1,0 +1,33 @@
+import { Event } from "./event";
+import { nanoid } from "nanoid";
+import { Talk } from "./talk";
+
+test("Successful JSON conversion", () => {
+  const event = new Event(
+    "sample",
+    "2021-05-01",
+    nanoid(8),
+    [new Talk("aaa", "bbb", nanoid())],
+    "https://example.com",
+    "hashtag"
+  );
+  const eventString = JSON.stringify(event);
+  const result = Event.fromJSON(eventString);
+
+  expect(result).toStrictEqual(event);
+});
+
+test("Create from Obj", () => {
+  const eventId = nanoid(8);
+  const eventObj = {
+    id: eventId,
+    name: "tegehoge",
+    dateOfEvent: "2021-12-31",
+    talks: [{ id: nanoid(), title: "てげほげ", speakerName: "てげほげ" }],
+    externalUrl: "https://tege.work/",
+    hashtag: "tegehoge",
+  };
+  const event = Event.fromObj(eventObj);
+  expect(event.id).toStrictEqual(eventId);
+  expect(event.hashtag).toStrictEqual("tegehoge");
+});

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -62,7 +62,8 @@ export class Event {
       obj.dateOfEvent,
       obj.id,
       obj.talks.map((talk) => Talk.fromObj(talk)),
-      obj.externalUrl
+      obj.externalUrl,
+      obj.hashtag
     );
   }
 

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -67,7 +67,11 @@ export class Event {
   }
 
   isValid(): boolean {
-    return this.name.length > 0 && this.talks.some((talk) => !talk.isEmpty());
+    return (
+      this.name.length > 0 &&
+      /^([^\s!$%^&*+.]*[^0-9\s!$%^&*+.][^\s!$%^&*+.]*)?$/.test(this.hashtag || "") &&
+      this.talks.some((talk) => !talk.isEmpty())
+    );
   }
 
   isValidFuture(): boolean {

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -10,19 +10,22 @@ export class Event {
   dateOfEvent: string; // date
   talks: Talk[];
   externalUrl?: string; // URL
+  hashtag?: string;
 
   constructor(
     name: string,
     dateOfEvent: string,
     id?: EventId,
     talks?: Talk[],
-    externalUrl?: string
+    externalUrl?: string,
+    hashtag?: string
   ) {
     this.id = id || nanoid(8);
     this.name = name;
     this.dateOfEvent = dateOfEvent;
     this.talks = talks || [];
     this.externalUrl = externalUrl;
+    this.hashtag = hashtag;
   }
 
   setExternalUrl(url: string): void {
@@ -48,7 +51,8 @@ export class Event {
       data.dateOfEvent,
       data.id,
       data.talks.map((talk) => Talk.fromObj(talk)),
-      data.externalUrl
+      data.externalUrl,
+      data.hashtag
     );
   }
 
@@ -77,6 +81,7 @@ export type EventResponse = {
   dateOfEvent: string; // date
   talks: TalkResponse[];
   externalUrl?: string; // URL
+  hashtag?: string;
 };
 
 export const emptyEvent = (): Event => new Event("", dayjs().format("YYYY-MM-DD"));

--- a/src/pages/Event.vue
+++ b/src/pages/Event.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="flex flex-col h-screen">
-    <event-header :event-id="eventId" :event-title="event ? event.name : ''"></event-header>
+    <event-header
+      :event-id="eventId"
+      :event-title="event?.name || ''"
+      :event-hashtag="event?.hashtag || ''"
+    ></event-header>
     <div v-if="event" id="comments" class="flex-grow overflow-auto" @scroll="checkRead()">
       <div class="flex flex-wrap max-w-4xl mx-auto">
         <CommentBlock


### PR DESCRIPTION
## issue

#61

## レビューしてほしいこと

- `#` を含まない値で保存します（このほうが色々便利）
- イベントページに「つぶやく」ボタンを設置。スマホではメニュー内に隠す。
- LeacTionのTwitterシェアの際にハッシュタグを追加。ついでに、 `#LeacTion` もつける。

## TODO

- [x] 入力バリデーション（ハッシュタグに使えない文字のチェック）