### PR TITLE
link-text クラスを有効にする

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,8 +15,8 @@
     @apply border-2 border-gray-400 rounded px-2 py-2;
     height: 44px;
   }
+}
 
-  .link-text {
-    @apply text-blue-700 underline;
-  }
+.link-text {
+  @apply text-blue-700 underline;
 }


### PR DESCRIPTION
`@layer components` 内の `.link-text` のみ適用されてなかった…。

## issue

#94 