### PR TITLE
Firestoreのコレクション名を変更する

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,7 @@ service cloud.firestore {
     match /{document=**} {
       allow read, write: if false;
     }
-    match /events/{eventId} {
+    match /events_v2/{eventId} {
       allow get: if request.auth != null;
       allow list, create: if request.auth != null && request.auth.token.firebase.sign_in_provider != "anonymous";
       allow update, delete: if request.auth != null && request.auth.uid in resource.data.managers;
@@ -17,7 +17,7 @@ service cloud.firestore {
         allow delete: if request.auth != null && request.auth.uid == resource.data.postedBy;
       }
     }
-    match /accounts/{accountId} {
+    match /accounts_v2/{accountId} {
       allow read: if request.auth != null && request.auth.token.firebase.sign_in_provider != "anonymous";
       allow write: if request.auth != null && request.auth.uid == accountId;
     }

--- a/src/features/account/api/firestore.ts
+++ b/src/features/account/api/firestore.ts
@@ -18,10 +18,10 @@ import { Account } from "../types";
  * @returns DocumentReference
  */
 export const accountDoc = (firestore: Firestore, uid: string) =>
-  doc(firestore, "accounts", uid).withConverter(AccountFirestoreConverter);
+  doc(firestore, "accounts_v2", uid).withConverter(AccountFirestoreConverter);
 
 export const accountCollection = (firestore: Firestore) =>
-  collection(firestore, "accounts").withConverter(AccountFirestoreConverter);
+  collection(firestore, "accounts_v2").withConverter(AccountFirestoreConverter);
 
 /**
  * Firestore上のデータと相互変換するためのコンバーター

--- a/src/features/comment/api/firestoreConversion.ts
+++ b/src/features/comment/api/firestoreConversion.ts
@@ -19,7 +19,7 @@ import { Comment } from "../types";
  * @returns コメントのFirestoreドキュメント
  */
 export const commentDoc = (firestore: Firestore, eventId: string, id: string) =>
-  doc(firestore, "events", eventId, "comments", id).withConverter(CommentFirestoreConverter);
+  doc(firestore, "events_v2", eventId, "comments", id).withConverter(CommentFirestoreConverter);
 
 /**
  * イベント内のコメントのFirestoreコレクションを取得
@@ -28,7 +28,7 @@ export const commentDoc = (firestore: Firestore, eventId: string, id: string) =>
  * @returns コメントのFirestoreコレクション
  */
 export const commentCollection = (firestore: Firestore, eventId: string) =>
-  collection(firestore, "events", eventId, "comments").withConverter(CommentFirestoreConverter);
+  collection(firestore, "events_v2", eventId, "comments").withConverter(CommentFirestoreConverter);
 
 /**
  * Firestore上のデータと相互変換するためのコンバーター

--- a/src/features/event/api/firestore.ts
+++ b/src/features/event/api/firestore.ts
@@ -18,7 +18,7 @@ import { Event } from "../types";
  * @returns イベントのFirestoreドキュメント
  */
 export const eventDoc = (firestore: Firestore, id: string) =>
-  doc(firestore, `events/${id}`).withConverter(EventFirestoreConverter);
+  doc(firestore, "events_v2", id).withConverter(EventFirestoreConverter);
 
 /**
  * イベントのFirestoreコレクションを取得
@@ -26,7 +26,7 @@ export const eventDoc = (firestore: Firestore, id: string) =>
  * @returns イベントのFirestoreコレクション
  */
 export const eventCollection = (firestore: Firestore) =>
-  collection(firestore, "events").withConverter(EventFirestoreConverter);
+  collection(firestore, "events_v2").withConverter(EventFirestoreConverter);
 
 /**
  * Firestore上のデータと相互変換するためのコンバーター


### PR DESCRIPTION
- accounts -> accounts_v2
- events -> events_v2

特に `events` は旧版と同名になってしまうのでデータが混ざってしまう。
そのために、明示的に `_v2` を付けてデータを分離することにした。