### PR TITLE
イベントページアクセス時にイベント情報やコメントを取得するリクエストに制限をつけない

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,12 +5,12 @@ service cloud.firestore {
       allow read, write: if false;
     }
     match /events_v2/{eventId} {
-      allow get: if request.auth != null;
+      allow get;
       allow list, create: if request.auth != null && request.auth.token.firebase.sign_in_provider != "anonymous";
       allow update, delete: if request.auth != null && request.auth.uid in resource.data.managers;
       allow update: if request.auth != null && (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['managerRequests']));
       match /comments/{commentId} {
-        allow read: if request.auth != null;
+        allow read;
         allow create: if request.auth != null;
         allow update: if request.auth != null && (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['likedBy']));
         // ref: https://firebase.google.com/docs/firestore/security/rules-fields#allowing_only_certain_fields_to_be_changed


### PR DESCRIPTION
LeacTion初回利用者がイベントページのURLにアクセスした際に匿名認証を付与するが、
匿名認証の付与に前後して非同期でイベント情報の取得を行うため、
イベント情報の取得時に認証情報の要求があると認証エラーで弾かれるケースがある。

今回の修正ではイベントのID指定での取得及びイベントに関するコメントの取得に関して認証を要求しないことにした。
イベントの一覧での取得や書き込みについては必要な認証を要求している。