### PR TITLE
未読管理のバグ修正

### DIFF
--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -67,13 +67,15 @@ const EventPage: VoidComponent = () => {
     } else {
       setUnread(true);
     }
+    updateScrollPosition();
   });
   onCleanup(unsubscribeComments);
 
   const [talkId, setTalkId] = createSignal(searchParams.tid || "");
   const selectTalkId = (talkId: string) => {
     setSearchParams({ tid: talkId }, { replace: true });
-    return setTalkId(talkId);
+    setTalkId(talkId);
+    return resetScrollPosition();
   };
 
   createEffect(() => {
@@ -106,13 +108,19 @@ const EventPage: VoidComponent = () => {
     commentBox.scrollTop = commentBox.scrollHeight - commentBox.clientHeight;
   };
 
-  const detectScroll = () => {
+  const updateScrollPosition = () => {
     if (commentBox.clientHeight + commentBox.scrollTop === commentBox.scrollHeight) {
       setIsBottom(true);
       setUnread(false);
     } else {
       setIsBottom(false);
     }
+  };
+
+  const resetScrollPosition = () => {
+    setIsBottom(false);
+    setUnread(true);
+    updateScrollPosition();
   };
 
   return (
@@ -138,7 +146,7 @@ const EventPage: VoidComponent = () => {
               backgroundColor="#c1e4e9"
               flexGrow={1}
               overflow="auto"
-              onscroll={detectScroll}
+              onscroll={updateScrollPosition}
               ref={commentBox}
             >
               <CommentList

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -72,9 +72,9 @@ const EventPage: VoidComponent = () => {
   onCleanup(unsubscribeComments);
 
   const [talkId, setTalkId] = createSignal(searchParams.tid || "");
-  const selectTalkId = (talkId: string) => {
-    setSearchParams({ tid: talkId }, { replace: true });
-    setTalkId(talkId);
+  const selectTalkId = (newTalkId: string) => {
+    setSearchParams({ tid: newTalkId }, { replace: true });
+    setTalkId(newTalkId);
     return resetScrollPosition();
   };
 


### PR DESCRIPTION
## Issue

コメントが投稿されていないイベントページを表示しても「最新のコメントを見る」ボタンが表示されていた。

## 関連PR

#145 のバグ修正

## やったこと

最新コメント取得時（特にページ初回表示時）と発表切替時にスクロールの状態を再取得する。

## 画面キャプチャ

## 動作確認

## レビューして欲しいポイント